### PR TITLE
fix "(node) Buffer.set is deprecated. Use array indexes instead."

### DIFF
--- a/src/bchaddr.js
+++ b/src/bchaddr.js
@@ -292,9 +292,7 @@ function decodeCashAddressWithPrefix (address) {
  */
 function encodeAsLegacy (decoded) {
   var versionByte = VERSION_BYTE[Format.Legacy][decoded.network][decoded.type]
-  var buffer = Buffer.alloc(1 + decoded.hash.length)
-  buffer[0] = versionByte
-  buffer.set(decoded.hash, 1)
+  var buffer = Buffer.concat([Buffer.from([versionByte]), Buffer.from(decoded.hash)])
   return bs58check.encode(buffer)
 }
 
@@ -306,9 +304,7 @@ function encodeAsLegacy (decoded) {
  */
 function encodeAsBitpay (decoded) {
   var versionByte = VERSION_BYTE[Format.Bitpay][decoded.network][decoded.type]
-  var buffer = Buffer.alloc(1 + decoded.hash.length)
-  buffer[0] = versionByte
-  buffer.set(decoded.hash, 1)
+  var buffer = Buffer.concat([Buffer.from([versionByte]), Buffer.from(decoded.hash)])
   return bs58check.encode(buffer)
 }
 


### PR DESCRIPTION
It will cause buffer bytes been 0 from index 1.Like below.
<Buffer 1c 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00>