### PR TITLE
Correctly prefix cashaddr addresses in toCashAddress

### DIFF
--- a/src/bchaddr.js
+++ b/src/bchaddr.js
@@ -118,9 +118,6 @@ function toBitpayAddress (address) {
  */
 function toCashAddress (address) {
   var decoded = decodeAddress(address)
-  if (decoded.format === Format.Cashaddr) {
-    return address
-  }
   return encodeAsCashaddr(decoded)
 }
 

--- a/test/bchaddr.js
+++ b/test/bchaddr.js
@@ -214,7 +214,7 @@ describe('bchaddr', function () {
     'bitcoincash:qrmed4fxlhkgay9nxw7zn9muew5ktkyjnuuawvycze',
     'bitcoincash:qqv3cpvmu4h0vqa6aly0urec7kwtuhe49yz6e7922v',
     'bitcoincash:qr39scfteeu5l573lzerchh6wc4cqkxeturafzfkk9',
-    'bitcoincash:qzzjgw37vwls805c9fw6g9vqyupadst6wgmane0s4l'
+    'bitcoincash:qzzjgw37vwls805c9fw6g9vqyupadst6wgmane0s4l',
   ]
 
   var CASHADDR_MAINNET_P2SH_ADDRESSES = [
@@ -506,6 +506,12 @@ describe('bchaddr', function () {
     it('should translate cashaddr address format to itself correctly', function () {
       assert.deepEqual(
         CASHADDR_ADDRESSES.map(bchaddr.toCashAddress),
+        CASHADDR_ADDRESSES
+      )
+    })
+    it('should translate no-prefix cashaddr address format to itself correctly', function () {
+      assert.deepEqual(
+        CASHADDR_ADDRESSES_NO_PREFIX.map(bchaddr.toCashAddress),
         CASHADDR_ADDRESSES
       )
     })


### PR DESCRIPTION
Currently, if ``toCashAddress`` was given a cashaddr format address with no prefix, it would return the bare address without the correct prefix. This fixes that. This is important for consistency, validity of return addresses and is handy for automatically prefixing the correct network prefix if you only have the raw address.

Added tests which fail without the change and pass with it.