### PR TITLE
Use older syntax for creating the Uint8Array, for better compatibility

### DIFF
--- a/src/bchaddr.js
+++ b/src/bchaddr.js
@@ -328,7 +328,7 @@ function encodeAsBitpay (decoded) {
 function encodeAsCashaddr (decoded) {
   var prefix = decoded.network === Network.Mainnet ? 'bitcoincash' : 'bchtest'
   var type = decoded.type === Type.P2PKH ? 'P2PKH' : 'P2SH'
-  var hash = Uint8Array.from(decoded.hash)
+  var hash = new Uint8Array(decoded.hash)
   return cashaddr.encode(prefix, type, hash)
 }
 


### PR DESCRIPTION
Uint8Array.from() is currently not supported in React Native